### PR TITLE
feat: Implement user level and bonus system

### DIFF
--- a/src/referalbot/api/routes.py
+++ b/src/referalbot/api/routes.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter, HTTPException
-from sqlalchemy import select, func
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 from src.referalbot.database.models import User, Purchase, BonusHistory
 from src.referalbot.database.db import async_session
+from src.referalbot.database.repository import get_level_by_turnover
 from pydantic import BaseModel
 import gspread
 from oauth2client.service_account import ServiceAccountCredentials
@@ -9,7 +11,7 @@ from aiogram import Bot
 from src.referalbot.config import TELEGRAM_TOKEN
 
 router = APIRouter()
-bot = Bot(token=TELEGRAM_TOKEN) # Создаем экземпляр бота для отправки сообщений
+bot = Bot(token=TELEGRAM_TOKEN)
 
 class PurchaseCreate(BaseModel):
     user_id: int
@@ -19,7 +21,7 @@ class PurchaseCreate(BaseModel):
 class PurchaseUpdate(BaseModel):
     bonus_paid: bool
 
-async def log_bonus_history(session, user_id, amount, operation, description):
+async def log_bonus_history(session, user_id, amount, operation, description, purchase_id=None):
     status = 'pending' if amount > 0 else 'available'
 
     history = BonusHistory(
@@ -27,7 +29,8 @@ async def log_bonus_history(session, user_id, amount, operation, description):
         amount=amount,
         operation=operation,
         description=description,
-        status=status
+        status=status,
+        purchase_id=purchase_id
     )
     session.add(history)
     await session.flush()
@@ -111,54 +114,58 @@ async def list_users():
 @router.post("/purchases")
 async def create_purchase(purchase: PurchaseCreate):
     async with async_session() as session:
-        user_result = await session.execute(select(User).filter_by(id=purchase.user_id))
-        user = user_result.scalar_one_or_none()
-        if not user:
-            raise HTTPException(status_code=404, detail="Пользователь не найден")
+        async with session.begin():
+            user_result = await session.execute(select(User).filter_by(id=purchase.user_id))
+            user = user_result.scalar_one_or_none()
+            if not user:
+                raise HTTPException(status_code=404, detail="Пользователь не найден")
 
-        calculated_bonus_amount = 0
-        if user.invited_by_id:
-            calculated_bonus_amount = int(round(purchase.amount * 0.05))
+            calculated_bonus_amount = 0
+            if user.invited_by_id:
+                # Eagerly load the inviter to access their turnover
+                inviter_res = await session.execute(
+                    select(User).options(selectinload(User.referrals)).filter_by(id=user.invited_by_id)
+                )
+                inviter = inviter_res.scalar_one()
 
-        new_purchase = Purchase(
-            user_id=purchase.user_id,
-            amount=purchase.amount,
-            discount_applied=purchase.discount_applied,
-            bonus_amount=calculated_bonus_amount
-        )
+                # Calculate potential new turnover to determine bonus rate
+                potential_turnover = inviter.turnover + purchase.amount
+                level_data = get_level_by_turnover(potential_turnover)
+                bonus_rate = level_data["rate"]
 
-        session.add(new_purchase)
-        await session.commit()
-        await session.refresh(new_purchase)
+                calculated_bonus_amount = int(round(purchase.amount * bonus_rate))
 
-        #log_to_google_sheet(new_purchase, user)
-
-        if user.invited_by_id and calculated_bonus_amount > 0:
-            # Логируем начисление бонуса
-            await log_bonus_history(
-                session,
-                user.invited_by_id,
-                calculated_bonus_amount,
-                "Начисление",
-                f"За покупку от {user.username} (ID: {new_purchase.id})"
+            new_purchase = Purchase(
+                user_id=purchase.user_id,
+                amount=purchase.amount,
+                discount_applied=purchase.discount_applied,
+                bonus_amount=calculated_bonus_amount
             )
+            session.add(new_purchase)
+            await session.flush() # Use flush to get new_purchase.id
 
-            # >> НОВОЕ: Отправляем уведомление о начислении бонуса <<
-            inviter_result = await session.execute(select(User).filter_by(id=user.invited_by_id))
-            inviter = inviter_result.scalar_one_or_none()
-            if inviter and inviter.telegram_id:
-                try:
-                    await bot.send_message(
-                        chat_id=inviter.telegram_id,
-                        text=f"🎉 Вам начислен бонус: +{calculated_bonus_amount:,} IDR за покупку вашего реферала {user.username}."
-                    )
-                except Exception as e:
-                    print(f"Не удалось отправить уведомление пользователю {inviter.telegram_id}: {e}")
+            if user.invited_by_id and calculated_bonus_amount > 0:
+                await log_bonus_history(
+                    session,
+                    user.invited_by_id,
+                    calculated_bonus_amount,
+                    "Начисление",
+                    f"За покупку от {user.username} (ID: {new_purchase.id})",
+                    purchase_id=new_purchase.id  # Pass the new purchase ID
+                )
+
+                # Send notification to inviter
+                if inviter and inviter.telegram_id:
+                    try:
+                        await bot.send_message(
+                            chat_id=inviter.telegram_id,
+                            text=f"🎉 Вам начислен бонус: +{calculated_bonus_amount:,} IDR за покупку вашего реферала {user.username}. Бонус станет доступен через 14 дней."
+                        )
+                    except Exception as e:
+                        print(f"Не удалось отправить уведомление пользователю {inviter.telegram_id}: {e}")
             
             await session.commit()
-
-
-        return {"message": "Покупка создана", "purchase_id": new_purchase.id, "bonus_amount": new_purchase.bonus_amount}
+            return {"message": "Покупка создана", "purchase_id": new_purchase.id, "bonus_amount": new_purchase.bonus_amount}
     
 @router.patch("/purchases/{purchase_id}")
 async def update_purchase(purchase_id: int, update: PurchaseUpdate):

--- a/src/referalbot/bot/handlers.py
+++ b/src/referalbot/bot/handlers.py
@@ -13,12 +13,51 @@ bot = Bot(token=TELEGRAM_TOKEN)
 
 def main_keyboard():
     keyboard = [
+        [InlineKeyboardButton(text="👤 Профиль", callback_data="show_profile")],
         [InlineKeyboardButton(text="Проверить бонусы", callback_data="check_bonuses")],
         [InlineKeyboardButton(text="История операций", callback_data="bonus_history")],
         [InlineKeyboardButton(text="Пригласить друга", callback_data="invite_friend")],
         [InlineKeyboardButton(text="Помощь", callback_data="help_info")],
     ]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+@router.callback_query(F.data == "show_profile")
+async def profile_callback(callback: types.CallbackQuery, session: AsyncSession):
+    logger.info(f"Обработка show_profile для пользователя {callback.from_user.id}")
+    try:
+        async with session.begin():
+            # get_bonus_balance also updates pending bonuses and recalculates turnover
+            balance_data = await repository.get_bonus_balance(session, callback.from_user.id)
+
+            # Re-fetch user to get the latest level and turnover
+            user = await repository.get_user_by_telegram_id(session, callback.from_user.id)
+            if not user:
+                await callback.message.answer("Сначала используйте /start.")
+                await callback.answer()
+                return
+
+        level_name = user.level
+        turnover_formatted = f"{int(user.turnover):,}"
+        balance_formatted = f"{int(balance_data['available_balance']):,}"
+
+        level_data = repository.get_level_by_turnover(user.turnover)
+        bonus_percent = int(level_data["rate"] * 100)
+
+        response_text = (
+            f"👤 <b>Ваш Профиль</b>\n\n"
+            f"🏆 Уровень: <b>{level_name} ({bonus_percent}%)</b>\n"
+            f"📈 Оборот: <b>{turnover_formatted} IDR</b>\n"
+            f"💰 Доступные бонусы: <b>{balance_formatted} IDR</b>\n\n"
+            f"Приглашайте друзей и увеличивайте свой уровень, чтобы получать еще больше бонусов!"
+        )
+
+        await callback.message.answer(response_text, parse_mode="HTML")
+        await callback.answer()
+
+    except Exception as e:
+        logger.error(f"Ошибка в show_profile: {e}")
+        await callback.message.answer("Произошла ошибка при отображении профиля.")
+        await callback.answer()
 
 @router.message(CommandStart(deep_link=True))
 async def start_with_referral(message: types.Message, command, session: AsyncSession):
@@ -53,7 +92,7 @@ async def start_with_referral(message: types.Message, command, session: AsyncSes
                 await message.answer(
                     f"Добро пожаловать в Bali Love, {html.escape(username)}!\n"
                     f"🎉 Ваш персональный промокод: {html.escape(user.promo_code)}\n\n"
-                    f"📩 Приглашайте друзей — за каждую их покупку вы получаете 5% от суммы на бонусный счёт. Бонусами можно оплатить любые услуги Bali Love или получить вознаграждение на банковский счет\n"
+                    f"📩 Приглашайте друзей — за каждую их покупку вы получаете бонус на свой счёт. Ваш процент зависит от вашего уровня и может достигать 20%!\n"
                     f" 1 бонус = 1 IDR\n\n"
                     f"💸 А ваши друзья получат скидку при первом обращении🔥\n\n"
                     f"Оформить визу 👉 @BaliLoveVisa\n"
@@ -79,7 +118,7 @@ async def start(message: types.Message, session: AsyncSession):
         await message.answer(
             f"Добро пожаловать в Bali Love, {html.escape(username)}!\n"
             f"🎉 Ваш персональный промокод: {html.escape(user.promo_code)}\n\n"
-            f"📩 Приглашайте друзей — за каждую их покупку вы получаете 5% от суммы на бонусный счёт. Бонусами можно оплатить любые услуги Bali Love или получить вознаграждение на банковский счет\n"
+            f"📩 Приглашайте друзей — за каждую их покупку вы получаете бонус на свой счёт. Ваш процент зависит от вашего уровня и может достигать 20%!\n"
             f" 1 бонус = 1 IDR\n\n"
             f"💸 А ваши друзья получат скидку при первом обращении🔥\n\n"
             f"Оформить визу 👉 @BaliLoveVisa\n"
@@ -97,7 +136,7 @@ async def help_command_callback(callback: types.CallbackQuery):
     try:
         await callback.message.answer(
             "Добро пожаловать в Bali Love Consulting🩷\n\n"
-            "Приглашай друзей и получай бонусы за их приобретения в нашем агентстве в размере 5% от стоимости покупки🔥\n"
+            "Приглашай друзей и получай бонусы за их приобретения в нашем агентстве. Ваш процент бонуса зависит от вашего уровня и может достигать 20%!\n"
             "Скидку на наши услуги в размере 5% получит так же приглашенный вами друг 😉\n\n"
             "1 бонус = 1 IDR\n\n"
             "<i>Вы можете потратить бонусы на наши услуги и получить скидку или получить их наличными на свой банковский счет</i>\n\n"
@@ -209,7 +248,7 @@ async def invite_friend_callback(callback: types.CallbackQuery, session: AsyncSe
         await callback.message.answer(
             f"Приглашайте друзей и зарабатывайте вместе с нами🩷 \n\n"
             f"Отправь эту ссылку другу: t.me/bali_referal_bot?start=REF_{user.promo_code}\n\n"
-            f"После того как он воспользуется нашими услугами по вашему промокоду: {promo_escaped} вам будет начислено 5% от стоимости его покупки, а друг получит скидку в размере 5% на наши услуги🔥\n\n"
+            f"После того как он воспользуется нашими услугами по вашему промокоду: {promo_escaped} вам будет начислен бонус от стоимости его покупки в зависимости от вашего уровня (до 20%), а друг получит скидку в размере 5% на наши услуги🔥\n\n"
             f"<i>Вы можете потратить бонусы на наши услуги и получить скидку или получить их наличными на свой банковский счет</i>\n\n"
             f"<i>Оформить визу 👉 @BaliLoveVisa</i>\n"
             f"<i>Получить вознаграждение 👉 @BaliLove_Johny</i>",

--- a/src/referalbot/database/models.py
+++ b/src/referalbot/database/models.py
@@ -16,6 +16,8 @@ class User(Base):
     promo_code = Column(String, unique=True)
     invited_by_id = Column(BigInteger, ForeignKey('users.id'), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
+    turnover = Column(BigInteger, default=0, nullable=False)
+    level = Column(String, default='Bronze', nullable=False)
     
     invited_by = relationship('User', remote_side=[id], back_populates='referrals')
     referrals = relationship('User', back_populates='invited_by', foreign_keys=[invited_by_id])
@@ -79,8 +81,10 @@ class BonusHistory(Base):
     description = Column(String)
     date = Column(DateTime, default=datetime.utcnow)
     status = Column(String, default='pending', nullable=False)
-    
+    purchase_id = Column(BigInteger, ForeignKey('purchases.id'), nullable=True)
+
     user = relationship('User', back_populates='bonus_history')
+    purchase = relationship('Purchase')
 
     def __str__(self) -> str:
         return f"Операция #{self.id} (user_id={self.user_id})"

--- a/src/referalbot/database/repository.py
+++ b/src/referalbot/database/repository.py
@@ -2,14 +2,63 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, and_, update
 from datetime import datetime, timedelta
 
-from src.referalbot.database.models import User, BonusHistory
+from src.referalbot.database.models import User, BonusHistory, Purchase
 from src.referalbot.bot.utils import generate_promo_code
+
+LEVELS = {
+    "Bronze": {"threshold": 0, "rate": 0.05},
+    "Silver": {"threshold": 50_000_000, "rate": 0.07},
+    "Gold": {"threshold": 80_000_000, "rate": 0.10},
+    "Platinum": {"threshold": 200_000_000, "rate": 0.20},
+}
+
+def get_level_by_turnover(turnover: int) -> dict:
+    """Determines a user's level based on their turnover."""
+    if turnover >= LEVELS["Platinum"]["threshold"]:
+        return {"level": "Platinum", "rate": LEVELS["Platinum"]["rate"]}
+    if turnover >= LEVELS["Gold"]["threshold"]:
+        return {"level": "Gold", "rate": LEVELS["Gold"]["rate"]}
+    if turnover >= LEVELS["Silver"]["threshold"]:
+        return {"level": "Silver", "rate": LEVELS["Silver"]["rate"]}
+    return {"level": "Bronze", "rate": LEVELS["Bronze"]["rate"]}
+
+async def recalculate_and_update_turnover(session: AsyncSession, user_id: int):
+    """
+    Recalculates the total turnover for a user based on confirmed purchases
+    of their referrals and updates the user's level.
+    Turnover is the sum of purchase amounts that resulted in an 'available' bonus.
+    """
+    stmt = (
+        select(func.coalesce(func.sum(Purchase.amount), 0))
+        .join(BonusHistory, BonusHistory.purchase_id == Purchase.id)
+        .where(
+            and_(
+                BonusHistory.user_id == user_id,
+                BonusHistory.status == 'available',
+                BonusHistory.purchase_id.isnot(None)
+            )
+        )
+    )
+    result = await session.execute(stmt)
+    total_turnover = result.scalar_one()
+
+    level_data = get_level_by_turnover(total_turnover)
+
+    update_stmt = (
+        update(User)
+        .where(User.id == user_id)
+        .values(turnover=total_turnover, level=level_data["level"])
+        .execution_options(synchronize_session=False)
+    )
+    await session.execute(update_stmt)
+
+    return {"turnover": total_turnover, "level": level_data["level"]}
 
 
 async def update_pending_bonuses(session: AsyncSession, user_id: int) -> None:
     """
     Updates the status of pending bonuses older than 14 days to 'available'.
-    This function commits the changes within its own scope.
+    If any bonuses are updated, it triggers a turnover recalculation for the user.
     """
     fourteen_days_ago = datetime.utcnow() - timedelta(days=14)
     stmt = (
@@ -24,7 +73,10 @@ async def update_pending_bonuses(session: AsyncSession, user_id: int) -> None:
         .values(status='available')
         .execution_options(synchronize_session=False)
     )
-    await session.execute(stmt)
+    result = await session.execute(stmt)
+
+    if result.rowcount > 0:
+        await recalculate_and_update_turnover(session, user_id)
 
 async def get_bonus_balance(session: AsyncSession, user_id: int) -> dict:
     """


### PR DESCRIPTION
This commit introduces a new user leveling system based on referral turnover.

Key features:
- Four user levels (Bronze, Silver, Gold, Platinum) with increasing bonus percentages (5%, 7%, 10%, 20%).
- User level is determined by the lifetime turnover generated by their referred users.
- Bonus calculation is now dynamic, based on the referrer's level at the time of purchase.
- The bonus for a transaction that triggers a level-up is calculated at the new, higher rate.
- A "Profile" section has been added to the bot, allowing users to view their current level, turnover, and available bonuses.
- Database models have been updated to support this new functionality, including adding `turnover` and `level` fields to the `User` model and linking `BonusHistory` to `Purchase`.
- Backend logic in the repository and API has been implemented to handle turnover recalculation and dynamic bonus assignment.
- All user-facing text in the bot has been updated to reflect the new system.