### PR TITLE
feat: Implement user level and bonus system

### DIFF
--- a/src/referalbot/api/routes.py
+++ b/src/referalbot/api/routes.py
@@ -3,7 +3,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 from src.referalbot.database.models import User, Purchase, BonusHistory
 from src.referalbot.database.db import async_session
-from src.referalbot.database.repository import get_level_by_turnover
+from src.referalbot.database.repository import get_level_by_turnover, recalculate_and_update_turnover
 from pydantic import BaseModel
 import gspread
 from oauth2client.service_account import ServiceAccountCredentials
@@ -17,12 +17,14 @@ class PurchaseCreate(BaseModel):
     user_id: int
     amount: int
     discount_applied: int = 5
+    bonus_paid: bool = False
 
 class PurchaseUpdate(BaseModel):
     bonus_paid: bool
 
-async def log_bonus_history(session, user_id, amount, operation, description, purchase_id=None):
-    status = 'pending' if amount > 0 else 'available'
+async def log_bonus_history(session, user_id, amount, operation, description, purchase_id=None, make_available=False):
+    # Bonus is made available immediately if make_available is True or if it's a withdrawal (amount <= 0)
+    status = 'available' if make_available or amount <= 0 else 'pending'
 
     history = BonusHistory(
         user_id=user_id,
@@ -112,57 +114,65 @@ async def list_users():
         return result
 
 @router.post("/purchases")
-async def create_purchase(purchase: PurchaseCreate):
+async def create_purchase(purchase_data: PurchaseCreate):
     async with async_session() as session:
         async with session.begin():
-            user_result = await session.execute(select(User).filter_by(id=purchase.user_id))
+            user_result = await session.execute(select(User).filter_by(id=purchase_data.user_id))
             user = user_result.scalar_one_or_none()
             if not user:
                 raise HTTPException(status_code=404, detail="Пользователь не найден")
 
             calculated_bonus_amount = 0
+            inviter = None
             if user.invited_by_id:
-                # Eagerly load the inviter to access their turnover
                 inviter_res = await session.execute(
                     select(User).options(selectinload(User.referrals)).filter_by(id=user.invited_by_id)
                 )
                 inviter = inviter_res.scalar_one()
 
-                # Calculate potential new turnover to determine bonus rate
-                potential_turnover = inviter.turnover + purchase.amount
+                potential_turnover = inviter.turnover + purchase_data.amount
                 level_data = get_level_by_turnover(potential_turnover)
                 bonus_rate = level_data["rate"]
 
-                calculated_bonus_amount = int(round(purchase.amount * bonus_rate))
+                calculated_bonus_amount = int(round(purchase_data.amount * bonus_rate))
 
             new_purchase = Purchase(
-                user_id=purchase.user_id,
-                amount=purchase.amount,
-                discount_applied=purchase.discount_applied,
-                bonus_amount=calculated_bonus_amount
+                user_id=purchase_data.user_id,
+                amount=purchase_data.amount,
+                discount_applied=purchase_data.discount_applied,
+                bonus_amount=calculated_bonus_amount,
+                bonus_paid=purchase_data.bonus_paid # Save the bonus_paid status
             )
             session.add(new_purchase)
-            await session.flush() # Use flush to get new_purchase.id
+            await session.flush()
 
-            if user.invited_by_id and calculated_bonus_amount > 0:
+            if user.invited_by_id and calculated_bonus_amount > 0 and inviter:
                 await log_bonus_history(
                     session,
-                    user.invited_by_id,
+                    inviter.id,
                     calculated_bonus_amount,
                     "Начисление",
                     f"За покупку от {user.username} (ID: {new_purchase.id})",
-                    purchase_id=new_purchase.id  # Pass the new purchase ID
+                    purchase_id=new_purchase.id,
+                    make_available=purchase_data.bonus_paid # Make bonus available if paid
                 )
 
+                # If the bonus was made available immediately, recalculate turnover now
+                if purchase_data.bonus_paid:
+                    await recalculate_and_update_turnover(session, inviter.id)
+
                 # Send notification to inviter
-                if inviter and inviter.telegram_id:
-                    try:
-                        await bot.send_message(
-                            chat_id=inviter.telegram_id,
-                            text=f"🎉 Вам начислен бонус: +{calculated_bonus_amount:,} IDR за покупку вашего реферала {user.username}. Бонус станет доступен через 14 дней."
-                        )
-                    except Exception as e:
-                        print(f"Не удалось отправить уведомление пользователю {inviter.telegram_id}: {e}")
+                notification_text = (
+                    f"🎉 Вам начислен бонус: +{calculated_bonus_amount:,} IDR за покупку вашего реферала {user.username}. "
+                    f"{'Бонус уже доступен!' if purchase_data.bonus_paid else 'Бонус станет доступен через 14 дней.'}"
+                )
+                try:
+                    await bot.send_message(
+                        chat_id=inviter.telegram_id,
+                        text=notification_text
+                    )
+                except Exception as e:
+                    print(f"Не удалось отправить уведомление пользователю {inviter.telegram_id}: {e}")
             
             await session.commit()
             return {"message": "Покупка создана", "purchase_id": new_purchase.id, "bonus_amount": new_purchase.bonus_amount}


### PR DESCRIPTION
This commit introduces a new user leveling system based on referral turnover. It also adds a feature to make bonuses immediately available upon creation.

Key features:
- Four user levels (Bronze, Silver, Gold, Platinum) with increasing bonus percentages (5%, 7%, 10%, 20%).
- User level is determined by the lifetime turnover generated by their referred users.
- Bonus calculation is now dynamic, based on the referrer's level at the time of purchase.
- The bonus for a transaction that triggers a level-up is calculated at the new, higher rate.
- A "Profile" section has been added to the bot, allowing users to view their current level, turnover, and available bonuses.
- An option to set `bonus_paid` to true on purchase creation, which makes the resulting bonus `available` immediately, bypassing the 14-day hold.
- Database models have been updated to support this new functionality.
- Backend logic has been implemented to handle all new features.
- All user-facing text in the bot has been updated to reflect the new system.