### PR TITLE
feat: Implement full-featured user level and bonus system

### DIFF
--- a/src/referalbot/database/repository.py
+++ b/src/referalbot/database/repository.py
@@ -85,6 +85,26 @@ async def update_user_level_if_needed(session: AsyncSession, user: User) -> None
 
 from sqlalchemy.orm import selectinload
 
+async def expire_old_bonuses(session: AsyncSession, user_id: int) -> None:
+    """
+    Updates the status of available bonuses older than 6 months (180 days) to 'expired'.
+    """
+    # Using 180 days as an approximation for 6 months
+    six_months_ago = datetime.utcnow() - timedelta(days=180)
+    stmt = (
+        update(BonusHistory)
+        .where(
+            and_(
+                BonusHistory.user_id == user_id,
+                BonusHistory.status == 'available',
+                BonusHistory.date < six_months_ago
+            )
+        )
+        .values(status='expired')
+        .execution_options(synchronize_session=False)
+    )
+    await session.execute(stmt)
+
 async def update_pending_bonuses(session: AsyncSession, user_id: int) -> None:
     """
     Updates the status of pending bonuses older than 14 days to 'available'.
@@ -118,9 +138,10 @@ async def update_pending_bonuses(session: AsyncSession, user_id: int) -> None:
 async def get_bonus_balance(session: AsyncSession, user_id: int) -> dict:
     """
     Calculates available, pending, and statistical bonus balances for a user.
-    It internally updates the status of matured bonuses.
+    It internally updates the status of matured and expired bonuses.
     """
-    # First, update statuses of any matured bonuses
+    # First, update statuses of any matured or expired bonuses
+    await expire_old_bonuses(session, user_id)
     await update_pending_bonuses(session, user_id)
 
     # 1. Calculate available balance


### PR DESCRIPTION
This commit implements a comprehensive user leveling and bonus system, incorporating monthly turnover for level-ups, permanent levels, and bonus expiration.

Key features:
- Four user levels (Bronze, Silver, Gold, Platinum) with increasing bonus percentages (5%, 7%, 10%, 20%).
- User level is permanent and only upgrades if turnover in a calendar month reaches a new threshold.
- Monthly turnover is calculated on-the-fly based on confirmed (`available`) referral purchases.
- Bonus calculation for new purchases is based on the user's permanent, non-expiring level.
- Bonuses automatically expire after 6 months. This is checked whenever a user's balance is queried.
- Admin panel (`sqladmin`) logic in `main.py` is updated to handle all new business rules.
- An option to set `bonus_paid` to true on purchase creation makes the resulting bonus `available` immediately.
- A "Profile" section in the bot displays the user's permanent level, its bonus rate, and their lifetime referral turnover.
- Code has been refactored for clarity, with business logic consolidated in `repository.py`.